### PR TITLE
fixes connection failure error (on windows)

### DIFF
--- a/north/adapter/postgres.rkt
+++ b/north/adapter/postgres.rkt
@@ -50,7 +50,7 @@ EOQ
            (query-exec conn "INSERT INTO north_schema_version VALUES ($1)" revision)))))])
 
 (define (url->postgres-adapter url)
-  (define database (substring (path->string (url->path url)) 1))
+  (define database (path/param-path (list-ref (url-path url) 0)))
   (match-define (list _ username password)
     (regexp-match #px"([^:]+)(?::(.+))?" (or (url-user url) "root")))
 


### PR DESCRIPTION
### environment
OS: Windows Server 2016 Datacenter
Postgresql: PostgreSQL 14.0
Racket: Racket v8.1 [bc]

### error log

```
D:\Users\dhpark\prjs\dip>set DATABASE_URL=postgres://id:pass@localhost:5432/test-db
D:\Users\dhpark\prjs\dip>raco north migrate
tcp-read: error reading
  system error: 현재 연결은 원격 호스트에 의해 강제로 끊겼습니다.; errid=10054
  context...:
   C:\racket\share\pkgs\db-lib\db\private\postgresql\message.rkt:505:0: parse-server-message
   C:\racket\share\pkgs\db-lib\db\private\postgresql\connection.rkt:129:4: check-ready-for-query method in connection-base%
   C:\racket\share\pkgs\db-lib\db\private\postgresql\connection.rkt:306:4: connect:expect-ready-for-query method in connection-base%
   C:\racket\collects\db\private\generic\common.rkt:308:13
   C:\racket\collects\db\private\generic\common.rkt:215:18
   C:\racket\collects\db\private\generic\common.rkt:180:8
   C:\racket\collects\db\private\generic\common.rkt:205:4: call-with-lock method in locking%
   C:\racket\share\pkgs\db-lib\db\private\postgresql\main.rkt:13:0: postgresql-connect
   C:\racket\collects\racket\contract\private\arrow-val-first.rkt:555:3
   D:\Users\dhpark\AppData\Roaming\Racket\8.1-bc\pkgs\north\adapter\postgres.rkt:52:0: url->postgres-adapter
   C:\racket\collects\racket\contract\private\arrow-higher-order.rkt:375:33
   D:\Users\dhpark\AppData\Roaming\Racket\8.1-bc\pkgs\north\cli.rkt:114:0: parse-migrator-args
   D:\Users\dhpark\AppData\Roaming\Racket\8.1-bc\pkgs\north\cli.rkt:180:0: handle-migrate
   "D:\Users\dhpark\AppData\Roaming\Racket\8.1-bc\pkgs\north\cli.rkt": [running body]
   "C:\racket\collects\raco\raco.rkt": [running body]
   "C:\racket\collects\raco\main.rkt": [running body]
```

database value in `(url->postgres-adapter)` was `"\localhost\test-db\"` which should be `"test-db"`.
so, i modified the way for getting database name from url.
I've tested on windows and ubuntu.
