### PR TITLE
adapter: try to use ssl first when connecting postgresql databases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
       uses: actions/checkout@master
 
     - name: Install Racket
-      uses: Bogdanp/setup-racket@v1.7
+      uses: Bogdanp/setup-racket@v1.8.1
       with:
-        version: "8.3"
+        version: "8.6"
 
     - name: Install pkg and deps
       run: raco pkg install --batch --auto north/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,11 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12.2
+        image: postgres:14
         env:
-          POSTGRES_USER: north_tests
-          POSTGRES_PASSWORD: north_tests
-          POSTGRES_DB: north_tests
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
         ports:
           - 5432/tcp
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
@@ -31,4 +31,5 @@ jobs:
       run: ./run-all-tests.sh
       working-directory: tests
       env:
-        PG_DATABASE_URL: postgres://north_tests:north_tests@127.0.0.1:${{ job.services.postgres.ports[5432] }}/north_tests
+        PG_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports[5432] }}/postgres
+        DATABASE_URL: postgres://north_tests:north_tests@127.0.0.1:${{ job.services.postgres.ports[5432] }}/north_tests

--- a/north/adapter/postgres.rkt
+++ b/north/adapter/postgres.rkt
@@ -74,4 +74,5 @@ EOQ
                        #:server host
                        #:port (url-port url)
                        #:user username
-                       #:password password)))
+                       #:password password
+                       #:ssl 'optional)))

--- a/north/north.scrbl
+++ b/north/north.scrbl
@@ -51,7 +51,7 @@ This tells @exec{north} to execute operations against an SQLite
 database located in the current directory called @filepath{db.sqlite}.
 @exec{DATABASE_URL} must have the following format:
 
-@verbatim|{protocol://[username[:password]@]hostname[:port]/database_name}|
+@verbatim|{protocol://[username[:password]@]hostname[:port]/database_name[?sslmode=prefer|require|disable]}|
 
 Assuming you wanted to use PostgreSQL instead of SQLite, your URL
 would look something like this:

--- a/tests/issue-002/test.sh
+++ b/tests/issue-002/test.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 ROOT=$(realpath "$(dirname "$0")")
 MIGRATIONS_FOLDER="$ROOT/migrations"
 FIXTURES_FOLDER="$ROOT/fixtures"
-export DATABASE_URL="${PG_DATABASE_URL:-postgres://north_tests@127.0.0.1/north_tests}"
+export DATABASE_URL="${DATABASE_URL:-postgres://north_tests@127.0.0.1/north_tests}"
+export PG_DATABASE_URL="${PG_DATABASE_URL:-postgres://postgres@127.0.0.1/postgres}"
 
 log() {
     printf "[%s] [issue-002] %s\\n" "$(date +%Y-%m-%dT%H:%M:%S)" "$@"
@@ -29,15 +30,14 @@ compare() {
 
 log "Cleaning up."
 log "DATABASE_URL=$DATABASE_URL"
-if [ -z "${CI+x}" ]; then
-    psql -dpostgres <<EOF
+log "PG_DATABASE_URL=$PG_DATABASE_URL"
+psql "$PG_DATABASE_URL" <<EOF
 DROP DATABASE IF EXISTS north_tests;
 DROP ROLE IF EXISTS north_tests;
 CREATE ROLE north_tests WITH PASSWORD 'north_tests' LOGIN;
 CREATE DATABASE north_tests;
 GRANT ALL PRIVILEGES ON DATABASE north_tests TO north_tests;
 EOF
-fi
 rm -fr "$MIGRATIONS_FOLDER"
 mkdir -p "$MIGRATIONS_FOLDER"
 

--- a/tests/postgres/test.sh
+++ b/tests/postgres/test.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 ROOT=$(realpath "$(dirname "$0")")
 MIGRATIONS_FOLDER="$ROOT/migrations"
 FIXTURES_FOLDER="$ROOT/fixtures"
-export DATABASE_URL="${PG_DATABASE_URL:-postgres://north_tests@127.0.0.1/north_tests}"
+export DATABASE_URL="${DATABASE_URL:-postgres://north_tests@127.0.0.1/north_tests}"
+export PG_DATABASE_URL="${PG_DATABASE_URL:-postgres://postgres@127.0.0.1/postgres}"
 
 log() {
     printf "[%s] [postgres] %s\\n" "$(date +%Y-%m-%dT%H:%M:%S)" "$@"
@@ -33,15 +34,13 @@ compare() {
 
 log "Cleaning up."
 log "DATABASE_URL=$DATABASE_URL"
-if [ -z "${CI+x}" ]; then
-    psql -dpostgres <<EOF
+psql "$PG_DATABASE_URL" <<EOF
 DROP DATABASE IF EXISTS north_tests;
 DROP ROLE IF EXISTS north_tests;
 CREATE ROLE north_tests WITH PASSWORD 'north_tests' LOGIN;
 CREATE DATABASE north_tests;
 GRANT ALL PRIVILEGES ON DATABASE north_tests TO north_tests;
 EOF
-fi
 rm -fr "$MIGRATIONS_FOLDER"
 mkdir -p "$MIGRATIONS_FOLDER"
 


### PR DESCRIPTION
Hosted postgresql databases, like Heroku Postgresql, require using ssl to connect the database [[heroku doc](https://help.heroku.com/DR0TTWWD/seeing-fatal-no-pg_hba-conf-entry-errors-in-postgres)]. 

This PR add `#:ssl 'optional` option when `postgresql-connect` in `url->postgres-adapter`. Obviously it brings some slowdown when connecting to a database which does not need to be connected with ssl; but it is not clear for me how to add such an option to the `raco north` command on whether using ssl or not, so I leave this PR as this.