### PR TITLE
psql: added schema option for the north migration table

### DIFF
--- a/north/adapter/postgres.rkt
+++ b/north/adapter/postgres.rkt
@@ -4,55 +4,57 @@
          net/url
          racket/contract/base
          racket/format
-         racket/lazy-require
          racket/match
          "base.rkt")
 
 (provide
  (contract-out
-  [struct postgres-adapter ([conn connection?] [schema string?])]
+  [struct postgres-adapter
+    ([conn connection?]
+     [schema string?])]
   [url->postgres-adapter (-> url? adapter?)]))
 
-(define (CREATE-SCHEMA-TABLE schema)
-  (format #<<EOQ
-CREATE TABLE IF NOT EXISTS ~s.north_schema_version(
+(define (~table ad)
+  (define schema (postgres-adapter-schema ad))
+  (format "~s.north_schema_version" schema))
+
+(define (~create-table ad)
+  (format #<<STMT
+CREATE TABLE IF NOT EXISTS ~a(
   current_revision TEXT NOT NULL
-) WITH (
-  fillfactor = 10
-);
-EOQ
-  schema)
-)
+) WITH (fillfactor = 10)
+STMT
+          (~table ad)))
 
 (struct postgres-adapter (conn schema)
   #:methods gen:adapter
   [(define (adapter-init ad)
      (define conn (postgres-adapter-conn ad))
-     (define schema (postgres-adapter-schema ad))
      (call-with-transaction conn
        (lambda ()
          (log-north-adapter-debug "creating schema table")
-         (query-exec conn (CREATE-SCHEMA-TABLE schema)))))
+         (query-exec conn (~create-table ad)))))
 
    (define (adapter-current-revision ad)
-     (define conn (postgres-adapter-conn ad))
-     (define schema (postgres-adapter-schema ad))
-     (query-maybe-value conn (format "SELECT current_revision FROM ~s.north_schema_version" schema)))
+     (query-maybe-value
+      (postgres-adapter-conn ad)
+      (format "SELECT current_revision FROM ~a" (~table ad))))
 
    (define (adapter-apply! ad revision scripts)
      (define conn (postgres-adapter-conn ad))
-     (define schema (postgres-adapter-schema ad))
+     (define table (~table ad))
      (with-handlers ([exn:fail:sql?
                       (lambda (e)
-                        (raise (exn:fail:adapter:migration @~a{failed to apply revision '@revision'}
-                                                           (current-continuation-marks) e revision)))])
+                        (raise (exn:fail:adapter:migration
+                                @~a{failed to apply revision '@revision'}
+                                (current-continuation-marks) e revision)))])
        (call-with-transaction conn
-        (lambda ()
-          (log-north-adapter-debug "applying revision ~a" revision)
-          (for ([script (in-list scripts)])
-            (query-exec conn script))
-          (query-exec conn (format "DELETE FROM ~s.north_schema_version" schema))
-          (query-exec conn (format "INSERT INTO ~s.north_schema_version VALUES ($1)" schema) revision)))))])
+         (lambda ()
+           (log-north-adapter-debug "applying revision ~a" revision)
+           (for ([script (in-list scripts)])
+             (query-exec conn script))
+           (query-exec conn (format "DELETE FROM ~a" table))
+           (query-exec conn (format "INSERT INTO ~a VALUES ($1)" table) revision)))))])
 
 (define (url->postgres-adapter url)
   (define (oops message)
@@ -84,14 +86,14 @@ EOQ
       [`(sslmode . ,value) (oops (format "invalid `sslmode' value: ~e" value))]))
   (define schema
     (match (assq 'schema query)
-      [#f "public"]
-      [`(schema . ,value) value]))
-
-  (postgres-adapter
-   (postgresql-connect #:database database
-                       #:server host
-                       #:port (url-port url)
-                       #:ssl sslmode
-                       #:user username
-                       #:password password)
-   schema))
+      [`(schema . ,value) value]
+      [#f "public"]))
+  (define conn
+    (postgresql-connect
+     #:database database
+     #:server host
+     #:port (url-port url)
+     #:ssl sslmode
+     #:user username
+     #:password password))
+  (postgres-adapter conn schema))

--- a/north/adapter/postgres.rkt
+++ b/north/adapter/postgres.rkt
@@ -10,44 +10,49 @@
 
 (provide
  (contract-out
-  [struct postgres-adapter ([conn connection?])]
+  [struct postgres-adapter ([conn connection?] [schema string?])]
   [url->postgres-adapter (-> url? adapter?)]))
 
-(define CREATE-SCHEMA-TABLE #<<EOQ
-CREATE TABLE IF NOT EXISTS north_schema_version(
+(define (CREATE-SCHEMA-TABLE schema)
+  (format #<<EOQ
+CREATE TABLE IF NOT EXISTS ~s.north_schema_version(
   current_revision TEXT NOT NULL
 ) WITH (
   fillfactor = 10
 );
 EOQ
+  schema)
 )
 
-(struct postgres-adapter (conn)
+(struct postgres-adapter (conn schema)
   #:methods gen:adapter
   [(define (adapter-init ad)
      (define conn (postgres-adapter-conn ad))
+     (define schema (postgres-adapter-schema ad))
      (call-with-transaction conn
        (lambda ()
          (log-north-adapter-debug "creating schema table")
-         (query-exec conn CREATE-SCHEMA-TABLE))))
+         (query-exec conn (CREATE-SCHEMA-TABLE schema)))))
 
    (define (adapter-current-revision ad)
      (define conn (postgres-adapter-conn ad))
-     (query-maybe-value conn "SELECT current_revision FROM north_schema_version"))
+     (define schema (postgres-adapter-schema ad))
+     (query-maybe-value conn (format "SELECT current_revision FROM ~s.north_schema_version" schema)))
 
    (define (adapter-apply! ad revision scripts)
      (define conn (postgres-adapter-conn ad))
+     (define schema (postgres-adapter-schema ad))
      (with-handlers ([exn:fail:sql?
                       (lambda (e)
                         (raise (exn:fail:adapter:migration @~a{failed to apply revision '@revision'}
                                                            (current-continuation-marks) e revision)))])
        (call-with-transaction conn
-         (lambda ()
-           (log-north-adapter-debug "applying revision ~a" revision)
-           (for ([script (in-list scripts)])
-             (query-exec conn script))
-           (query-exec conn "DELETE FROM north_schema_version")
-           (query-exec conn "INSERT INTO north_schema_version VALUES ($1)" revision)))))])
+        (lambda ()
+          (log-north-adapter-debug "applying revision ~a" revision)
+          (for ([script (in-list scripts)])
+            (query-exec conn script))
+          (query-exec conn (format "DELETE FROM ~s.north_schema_version" schema))
+          (query-exec conn (format "INSERT INTO ~s.north_schema_version VALUES ($1)" schema) revision)))))])
 
 (define (url->postgres-adapter url)
   (define (oops message)
@@ -55,7 +60,7 @@ EOQ
      (exn:fail:adapter
       (~a message
           "\n connection URLs must have the form:"
-          "\n  postgres://[username[:password]@]hostname[:port]/database_name[?sslmode=prefer|require|disable]")
+          "\n  postgres://[username[:password]@]hostname[:port]/database_name[?sslmode=prefer|require|disable][&schema=SCHEMA]")
       (current-continuation-marks)
       #f)))
   (define host (url-host url))
@@ -68,14 +73,19 @@ EOQ
     (path/param-path (car (url-path url))))
   (match-define (list _ username password)
     (regexp-match #px"([^:]+)(?::(.+))?" (or (url-user url) "root")))
+  (define query (url-query url))
   (define sslmode
-    (match (assq 'sslmode (url-query url))
+    (match (assq 'sslmode query)
       [#f 'no]
       ['(sslmode . "disable") 'no]
       ['(sslmode . "require") 'yes]
       ['(sslmode . "prefer") 'optional]
       [`(sslmode . #f) (oops "empty `sslmode'")]
       [`(sslmode . ,value) (oops (format "invalid `sslmode' value: ~e" value))]))
+  (define schema
+    (match (assq 'schema query)
+      [#f "public"]
+      [`(schema . ,value) value]))
 
   (postgres-adapter
    (postgresql-connect #:database database
@@ -83,4 +93,5 @@ EOQ
                        #:port (url-port url)
                        #:ssl sslmode
                        #:user username
-                       #:password password)))
+                       #:password password)
+   schema))

--- a/north/migrate.rkt
+++ b/north/migrate.rkt
@@ -20,7 +20,7 @@
   (define adapter
     (match (dbsystem-name (connection-dbsystem conn))
       ['sqlite3 (sqlite-adapter conn)]
-      ['postgresql (postgres-adapter conn)]
+      ['postgresql (postgres-adapter conn "public")]
       [name (error 'migrate "dbsystem not supported: ~a" name)]))
   (adapter-init adapter)
   (define current (adapter-current-revision adapter))


### PR DESCRIPTION
i needed this to allow running the same migration set on multiple schemas of the same database where i wanted each schema to own their own north migration history / schema.

is it something you're okay with merging?

the `~s` also is fitting as it escapes all strings into a pre-escaped `"`-bounded value which is what's used to target schemas, rows, and other entities of that kind